### PR TITLE
Legg til målinger med Prometheus

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
     #########################
     ### DEVELOPERS: Insert your feature branch name below (in addition to master) if you want to deploy it to dev
     #########################
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/lagring-av-utfall'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/prometheus-metrikker'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # rekrutteringsbistand-statistikk-api
-
 Aggregering, lagring og behandling av formidlingsstatistikk og annen statistikk knyttet til inkludering.
+
+Starte appen:
+Høyreklikk på `LokalApplication.kt` i IntelliJ og velg `Run`.
 
 
 # Henvendelser

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,16 +3,17 @@ val logbackVersion = "1.2.1"
 val ktorVersion = "1.3.2"
 val kotlinVersion = "1.3.72"
 val h2Version = "1.4.200"
-val flywayVersion = "6.4.3"
+val flywayVersion = "6.4.4"
 val hikariVersion = "3.4.5"
 val logstashEncoderVersion = "6.4"
 val vaultJdbcVersion = "1.3.7"
 val shadowVersion = "5.2.0"
-val postgresVersion = "42.2.12"
-val tokenValidationKtorVersion = "1.1.5"
-val tokenValidationTestSupportVersion = "1.1.5"
+val postgresVersion = "42.2.14"
+val tokenValidationKtorVersion = "1.1.6"
+val tokenValidationTestSupportVersion = "1.1.6"
 val jacksonVersion = "2.11.0"
 val assertkVersion = "0.22"
+val micrometerPrometheusVersion = "1.5.1"
 
 plugins {
     application
@@ -62,7 +63,10 @@ dependencies {
         exclude(group = "io.ktor", module = "ktor-auth")
     }
 
-    implementation("io.ktor:ktor-auth:1.3.2")
+    implementation("io.ktor:ktor-auth:$ktorVersion")
+
+    implementation("io.ktor:ktor-metrics-micrometer:$ktorVersion")
+    implementation("io.micrometer:micrometer-registry-prometheus:$micrometerPrometheusVersion")
 
     implementation("no.nav.security:token-validation-test-support:$tokenValidationTestSupportVersion") {
         exclude(group = "org.springframework.boot")

--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -15,7 +15,7 @@ spec:
     path: /rekrutteringsbistand-statistikk-api/internal/isReady
   prometheus:
     enabled: true
-    path: /internal/prometheus
+    path: /rekrutteringsbistand-statistikk-api/internal/prometheus
   vault:
     enabled: true
   webproxy: true

--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -13,6 +13,9 @@ spec:
     path: /rekrutteringsbistand-statistikk-api/internal/isAlive
   readiness:
     path: /rekrutteringsbistand-statistikk-api/internal/isReady
+  prometheus:
+    enabled: true
+    path: /internal/prometheus
   vault:
     enabled: true
   webproxy: true

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -15,7 +15,7 @@ spec:
     path: /rekrutteringsbistand-statistikk-api/internal/isReady
   prometheus:
     enabled: true
-    path: /internal/prometheus
+    path: /rekrutteringsbistand-statistikk-api/internal/prometheus
   vault:
     enabled: true
   webproxy: true

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -13,6 +13,9 @@ spec:
     path: /rekrutteringsbistand-statistikk-api/internal/isAlive
   readiness:
     path: /rekrutteringsbistand-statistikk-api/internal/isReady
+  prometheus:
+    enabled: true
+    path: /internal/prometheus
   vault:
     enabled: true
   webproxy: true

--- a/src/ApplicationEngine.kt
+++ b/src/ApplicationEngine.kt
@@ -7,12 +7,16 @@ import io.ktor.auth.Authentication
 import io.ktor.features.CallLogging
 import io.ktor.features.ContentNegotiation
 import io.ktor.jackson.jackson
+import io.ktor.metrics.micrometer.MicrometerMetrics
 import io.ktor.routing.route
 import io.ktor.routing.routing
 import io.ktor.server.engine.ApplicationEngine
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.util.KtorExperimentalAPI
+import io.micrometer.core.instrument.Metrics
+import io.micrometer.prometheus.PrometheusConfig
+import io.micrometer.prometheus.PrometheusMeterRegistry
 import no.nav.rekrutteringsbistand.statistikk.db.DatabaseInterface
 import no.nav.rekrutteringsbistand.statistikk.kandidatutfall.kandidatutfall
 import no.nav.rekrutteringsbistand.statistikk.nais.naisEndepunkt
@@ -33,10 +37,16 @@ fun lagApplicationEngine(
         }
         install(Authentication, tokenValidationConfig)
 
+        val prometheusMeterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+        install(MicrometerMetrics) {
+            registry = prometheusMeterRegistry
+        }
+        Metrics.addRegistry(prometheusMeterRegistry)
+
         routing {
             route("/rekrutteringsbistand-statistikk-api") {
+                naisEndepunkt(prometheusMeterRegistry)
                 kandidatutfall(database)
-                naisEndepunkt()
             }
         }
     }

--- a/src/kandidatutfall/Kandidatutfall.kt
+++ b/src/kandidatutfall/Kandidatutfall.kt
@@ -40,7 +40,7 @@ fun Route.kandidatutfall(database: DatabaseInterface) {
 
             kandidatutfall.forEach {
                 database.lagreUtfall(it)
-                Metrics.counter("rekrutteringsbisatnd.statistikk.utfall.lagret").increment()
+                Metrics.counter("rekrutteringsbistand.statistikk.utfall.lagret", "utfall", it.utfall).increment()
             }
 
             call.respond(HttpStatusCode.Created)

--- a/src/kandidatutfall/Kandidatutfall.kt
+++ b/src/kandidatutfall/Kandidatutfall.kt
@@ -7,6 +7,7 @@ import io.ktor.request.receive
 import io.ktor.response.respond
 import io.ktor.routing.Route
 import io.ktor.routing.post
+import io.micrometer.core.instrument.Metrics
 import no.nav.rekrutteringsbistand.statistikk.db.DatabaseInterface
 import no.nav.rekrutteringsbistand.statistikk.log
 import java.time.LocalDateTime
@@ -39,6 +40,7 @@ fun Route.kandidatutfall(database: DatabaseInterface) {
 
             kandidatutfall.forEach {
                 database.lagreUtfall(it)
+                Metrics.counter("rekrutteringsbisatnd.statistikk.utfall.lagret").increment()
             }
 
             call.respond(HttpStatusCode.Created)

--- a/src/nais/NaisEndepunkt.kt
+++ b/src/nais/NaisEndepunkt.kt
@@ -4,12 +4,18 @@ import io.ktor.application.call
 import io.ktor.response.respond
 import io.ktor.routing.Route
 import io.ktor.routing.get
+import io.micrometer.prometheus.PrometheusMeterRegistry
 
-fun Route.naisEndepunkt() {
+fun Route.naisEndepunkt(prometheusMeterRegistry: PrometheusMeterRegistry) {
     get("/internal/isAlive") {
         call.respond("Alive")
     }
+
     get("/internal/isReady") {
         call.respond("Ready")
+    }
+
+    get("/internal/prometheus") {
+        call.respond(prometheusMeterRegistry.scrape())
     }
 }


### PR DESCRIPTION
Denne PRen legger til eksportering av målinger med Prometheus.
Har slått på default metrikker, mest interessant her er logging av HTTP-kall inn til API-et og responskoder.
Kan også eksponere egne metrikker med [Micrometer](https://micrometer.io/docs/concepts) ved å bruke f.eks. `Metrics.counter("en.counter")` eller `Metrics.timer("en.timer").record { kode man ønsker å ta tiden på }`.
